### PR TITLE
Add unicode test, update readme, fix parameter-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Another method would be to use the requests module in python.
 ````python
 import requests
 
-requests.post('http://localhost:5000/', json={"sql-query": 'SELECT * FROM real_identity WHERE alterego="Batman";'})
+requests.post('http://localhost:5000/', json={"sql-query": 'SELECT * FROM real_identity WHERE alterego="Batman";'}).json()
 ````
 
 ## Help
@@ -149,8 +149,11 @@ requests.post('http://localhost:5000/', json={"sql-query": 'SELECT * FROM real_i
 * SQLRestAPI Connection issues
     * Remember to expose the port (default 5000) in the Dockerfile in case you are running as a container, and to forward that port with the '-p 5000:5000' (or similar) flag.
     * If your script stops due to an exception or exits at the end of the script, the webservice will be taken down - create a loop and/or check for errors.
-    * If you set 'wait_for_ready' to False, be aware you can theoretically send requests before it is ready - give it a moment or use the default wait setup.
-    * The API responds with "The browser (or proxy) sent a request that this server could not understand.", please make sure you are using a json-payload.
+    * If you set 'wait_for_ready' to False, be aware you can theoretically send requests before the webserver is ready - give it a moment or use the default wait setup.
+    * If the API responds with "The browser (or proxy) sent a request that this server could not understand.", please make sure you are using a json-payload.
+
+* SQLRestAPI data issues
+    * Non-ascii characters are encoded as unicode (\uxxxx) - the requests.json() function will decode this, otherwise you will have to do it yourself.
 
 See the [open issues](https://github.com/energinet-singularity/singupy/issues) for a full list of proposed features (and known issues).
 If you are facing unidentified issues with the library, please submit an issue or ask the authors.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'Flask-RESTful>=0.3.9',
         'requests>=2.27.1'
     ],
-    version='0.1.1',
+    version='0.1.2',
     license='Apache License 2.0',
     description='Library for Singularity',
     long_description=open('README.md').read(),

--- a/singupy/api.py
+++ b/singupy/api.py
@@ -61,7 +61,7 @@ class SQLRestAPI():
         host : str
             Can be changed if required, but will default to '0.0.0.0' which will allow access from outside as well
         '''
-        self._port = port
+        self.__port = port
         self.__host = host
         self.__endpoint = endpoint
         self.getcall = getcall
@@ -82,7 +82,7 @@ class SQLRestAPI():
 
     @property
     def port(self) -> int:
-        return self._port
+        return self.__port
 
     @port.setter
     def port(self, value: int):
@@ -90,7 +90,7 @@ class SQLRestAPI():
             log.error('Tried to set port while thread is running.')
             raise AttributeError('Cannot set port when thread is running.')
         else:
-            self._port = value
+            self.__port = value
             self.__update_process()
 
     @property
@@ -182,14 +182,14 @@ class SQLRestAPI():
         def __init__(self, host, port, app):
             self.__app = app
             self.__host = host
-            self._port = port
+            self.__port = port
             self.server = None
             Thread.__init__(self, daemon=True)
 
         def run(self):
             '''Run the webserver'''
             log.info('starting server')
-            self.server = make_server(host=self.__host, port=self._port, app=self.__app, threaded=True)
+            self.server = make_server(host=self.__host, port=self.__port, app=self.__app, threaded=True)
             self.server.serve_forever()
 
         def shutdown(self):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -18,7 +18,7 @@ def GetDummy():
 
 def PostDummy(query: str):
     if 'SELECT' in query:
-        return {"REST": "POST", "QUERY": query}
+        return {"REST": "POST", "QUERY": query, "DANISH": "ÆØÅ"}
     else:
         raise ValueError('I pity the fool!')
 
@@ -58,7 +58,7 @@ def test_SQLRestAPI(SQLRestAPI_resource):
     # Validate GET
     assert requests.get(f'http://localhost:{web.port}/{web.endpoint}').json() == GetDummy()
 
-    # Validate POST
+    # Validate POST (including unicode/dk characters!)
     query = "SELECT * FROM A-TEAM;"
     assert requests.post(f'http://localhost:{web.port}/{web.endpoint}',
                          json={"sql-query": query}).json() == PostDummy(query)


### PR DESCRIPTION
Added a unicode decode test ('æøå' in the post-call) and updated the readme to reflect the changes done in last commit. Furthermore fixed a minor variable mis-naming in the code.

Category:

- [ ] New Feature
- [x] Bugfix
- [x] Documentation update

Checklist:

- [x] I have bumped all relevant version numbers
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my changes if this is needed
- [x] I have described my changes in the "description of your changes" field
- [x] I have tested this change on a running cluster 
- [x] I have created/corrected automated tests related to the changes, if possible/necessary
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have squashed commits if necessary